### PR TITLE
Add log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ A list of variables to be used by the pipeline. If several variables are present
 
 The length of time to wait for completion. Values should contain a corresponding time unit e.g. 1s, 2m, 3h. If not specified it will use `5m`.
 
+### `tests`
+
+The test sections to run, separated by spaces. If no tests are specified all tests are run.
+
 ### `log-level`
 
 Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ A list of variables to be used by the pipeline. If several variables are present
 
 The length of time to wait for completion. Values should contain a corresponding time unit e.g. 1s, 2m, 3h. If not specified it will use `5m`.
 
+### `log-level`
+
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Relative path within the repository to the manifest file (default to okteto-pipe
 
 Deploy the dev environment always even if it has already been deployed
 
-### `nocache`
+### `no-cache`
 
 Do not use cache for runnings the tests
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   timeout:
     description: "The length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h  (default 5m0s)"
     required: false
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
+    required: false
   tests:
     description: "The test sections to run separated by spaces. If not tests are defined, all tests are ran. Eg: 'unit integration' "
     required: false
@@ -36,6 +39,7 @@ runs:
     - ${{ inputs.nocache }}
     - ${{ inputs.variables }}
     - ${{ inputs.timeout }}
+    - ${{ inputs.log-level }}
     - ${{ inputs.tests }}
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -22,11 +22,11 @@ inputs:
   timeout:
     description: "The length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h  (default 5m0s)"
     required: false
-  log-level:
-    description: "Log level string. Valid options are debug, info, warn, error"
-    required: false
   tests:
     description: "The test sections to run separated by spaces. If not tests are defined, all tests are ran. Eg: 'unit integration' "
+    required: false
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
     required: false
 runs:
   using: 'docker'
@@ -39,8 +39,8 @@ runs:
     - ${{ inputs.nocache }}
     - ${{ inputs.variables }}
     - ${{ inputs.timeout }}
-    - ${{ inputs.log-level }}
     - ${{ inputs.tests }}
+    - ${{ inputs.log-level }}
 
 branding:
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   deploy:
     description: 'Deploy the dev environment always even if it has already been deployed'
     required: false
-  nocache:
+  no-cache:
     description: 'Do not use the cache for runnings the tests'
     required: false
   variables:
@@ -36,7 +36,7 @@ runs:
     - ${{ inputs.namespace }}
     - ${{ inputs.file }}
     - ${{ inputs.deploy }}
-    - ${{ inputs.nocache }}
+    - ${{ inputs.no-cache }}
     - ${{ inputs.variables }}
     - ${{ inputs.timeout }}
     - ${{ inputs.tests }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ name=$1
 namespace=$2
 file=$3
 deploy=$4
-nocache=$5
+no_cache=$5
 variables=$6
 timeout=$7
 tests=$8
@@ -36,7 +36,7 @@ if [ "$deploy" = "true" ]; then
       params="$params --deploy"
 fi
 
-if [ "$nocache" = "true" ]; then
+if [ "$no_cache" = "true" ]; then
       params="$params --no-cache"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,8 +18,6 @@ if [ -n "$OKTETO_CA_CERT" ]; then
    update-ca-certificates
 fi
 
-command="test"
-
 params=""
 
 if [ -n "$name" ]; then
@@ -73,6 +71,6 @@ if [ "${RUNNER_DEBUG}" = "1" ]; then
   log_level="--log-level debug"
 fi
 
-echo running: okteto $log_level "$command" "$params"
+echo running: okteto test $log_level "$params"
 # shellcheck disable=SC2086
-okteto $command $log_level $params
+okteto test $log_level $params

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,22 +20,7 @@ fi
 
 command="test"
 
-if [ ! -z "$log_level" ]; then
-  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
-    log_level="--log-level ${log_level}"
-  else
-    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
-    exit 1
-  fi
-fi
-
-# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
-# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-if [ "${RUNNER_DEBUG}" = "1" ]; then
-  log_level="--log-level debug"
-fi
-
-params="$log_level"
+params=""
 
 if [ -n "$name" ]; then
    params="$params --name $name"
@@ -73,6 +58,21 @@ fi
 
 params="$params $tests"
 
-echo running: okteto "$command" "$params"
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+echo running: okteto $log_level "$command" "$params"
 # shellcheck disable=SC2086
-okteto $command $params
+okteto $command $log_level $params

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,8 @@ deploy=$4
 nocache=$5
 variables=$6
 timeout=$7
-log_level=$8
-tests=$9
+tests=$8
+log_level=$9
 
 if [ -n "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,8 @@ deploy=$4
 nocache=$5
 variables=$6
 timeout=$7
-tests="${@:8}"
+log_level=$8
+tests="${@:9}"
 
 if [ -n "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"
@@ -19,7 +20,22 @@ fi
 
 command="test"
 
-params="--progress plain"
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "log-level supported: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+params="--progress plain $log_level"
 
 if [ -n "$name" ]; then
    params="$params --name $name"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ if [ "${RUNNER_DEBUG}" = "1" ]; then
   log_level="--log-level debug"
 fi
 
-params="--progress plain $log_level"
+params="$log_level"
 
 if [ -n "$name" ]; then
    params="$params --name $name"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,12 +57,7 @@ fi
 params="$params $tests"
 
 if [ ! -z "$log_level" ]; then
-  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
-    log_level="--log-level ${log_level}"
-  else
-    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
-    exit 1
-  fi
+  log_level="--log-level ${log_level}"
 fi
 
 # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ nocache=$5
 variables=$6
 timeout=$7
 log_level=$8
-tests="${@:9}"
+tests=$9
 
 if [ -n "$OKTETO_CA_CERT" ]; then
    echo "Custom certificate is provided"


### PR DESCRIPTION
Resolves https://okteto.atlassian.net/browse/DEV-320

As done for deploy-preview this PR adds the input of log-level to the action in order to enable debug logging or any other level the user wants to use on the runs.

Additionally, changed the positional parameter for capturing tests, this is not needed as when the action is run the list of names is captured itself as a whole variable by entrypoint $tests

Removed `--progress` flag as this is not available at the `okteto test` command and the action was not able to work.

Tested running the pipeline using the last commit
https://github.com/teresaromero/go-getting-started/actions/workflows/test-actions.yml

