### PR TITLE
Add GitHub environment variables to params

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,13 @@ if [ ! -z "${variables}" ]; then
   params="${params} ${variable_params}"
 fi
 
+github_env_vars=$(env | grep '^GITHUB_')
+github_params=""
+for VAR in $github_env_vars; do
+   github_params="$github_params --var $VAR"
+done
+params="$params $github_params"
+
 
 if [ -n "$timeout" ]; then
    params="$params --timeout $timeout"


### PR DESCRIPTION
Fixes DEV-620
This pull request adds support for including GitHub environment variables in the params of the application. Previously, these variables were not being included, but now they will be added using the `--var` flag. This change ensures that the application has access to the necessary environment variables when running.