### PR TITLE
Add GitHub environment variables to params

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,13 @@ if [ ! -z "${variables}" ]; then
   params="${params} ${variable_params}"
 fi
 
+github_env_vars=$(env | grep '^GITHUB_')
+github_params=""
+for VAR in $github_env_vars; do
+   github_params="$github_params --var $VAR"
+done
+params="$params $github_params"
+
 
 if [ -n "$timeout" ]; then
    params="$params --timeout $timeout"


### PR DESCRIPTION
This pull request adds support for GitHub environment variables to the params in the code. Previously, these variables were not included in the params, but now they are added using the `--var` flag. This change ensures that the GitHub environment variables are properly passed to the code when running.

Cherrypick of https://github.com/okteto/test/pull/5