### PR TITLE
fix: ca and panic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/okteto/test/pkg/cert"
@@ -34,7 +35,7 @@ func main() {
 
 	runner := &command.DefaultRunner{}
 	log.Debug("Using default command runner")
-	if err := cert.HandleCaCert(userInput.CaCert, runner, fs, log); err != nil {
+	if err := cert.HandleCaCert(userInput.CaCert, runner, exec.LookPath, fs, log); err != nil {
 		log.Error("Error handling CA certificate: %v", slog.String("error", err.Error()))
 		os.Exit(2) // Return error code for certificate handling failure
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	userInput, err := input.NewInput(args, envVars)
 	if err != nil {
-		logger := slog.New(&slog.TextHandler{})
+		logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 		logger.Error("Error parsing input", slog.String("error", err.Error()))
 		os.Exit(1)
 	}

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -10,8 +10,11 @@ import (
 )
 
 const (
-	// oktetocaCertPath is the path to the CA certificate
-	oktetocaCertPath = "/usr/local/share/ca-certificates/okteto_ca_cert.crt"
+	// oktetoCACertPath is the path to the CA certificate
+	oktetoCACertPath = "/etc/ssl/certs/okteto_ca_cert.pem"
+
+	// oktetoCACertDebianPath is the path used when update-ca-certificates is available
+	oktetoCACertDebianPath = "/usr/local/share/ca-certificates/okteto_ca_cert.crt"
 
 	// updateCaCertificatesCmd is the command to update the CA certificates
 	updateCaCertificatesCmd = "update-ca-certificates"
@@ -25,28 +28,39 @@ var (
 	ErrWriteFailed = fmt.Errorf("failed to write CA cert")
 )
 
+// LookPathFunc is the signature for exec.LookPath
+type LookPathFunc func(string) (string, error)
+
 // InfoLogger is an interface for logging information
 type InfoLogger interface {
 	Info(msg string, keysAndValues ...interface{})
 }
 
 // HandleCaCert writes the CA certificate to the system and updates certificates
-func HandleCaCert(caCert string, runner command.CommandRunner, fs afero.Fs, l InfoLogger) error {
+func HandleCaCert(caCert string, runner command.CommandRunner, lookPath LookPathFunc, fs afero.Fs, l InfoLogger) error {
 	if caCert == "" {
 		l.Info("No CA certificate provided")
 		return nil
 	}
 
-	err := afero.WriteFile(fs, oktetocaCertPath, []byte(caCert), 0644)
-	if err != nil {
+	if err := afero.WriteFile(fs, oktetoCACertPath, []byte(caCert), 0644); err != nil {
 		return fmt.Errorf("%w: %w", ErrWriteFailed, err)
 	}
 	l.Info("CA certificate written successfully")
 
-	cmd := exec.Command(updateCaCertificatesCmd)
-	if err := runner.Run(cmd); err != nil {
-		return fmt.Errorf("%w: %w", ErrUpdateFailed, err)
+	if _, err := lookPath(updateCaCertificatesCmd); err == nil {
+		if err := fs.MkdirAll("/usr/local/share/ca-certificates", 0755); err != nil {
+			return fmt.Errorf("%w: %w", ErrWriteFailed, err)
+		}
+		if err := afero.WriteFile(fs, oktetoCACertDebianPath, []byte(caCert), 0644); err != nil {
+			return fmt.Errorf("%w: %w", ErrWriteFailed, err)
+		}
+		cmd := exec.Command(updateCaCertificatesCmd)
+		if err := runner.Run(cmd); err != nil {
+			return fmt.Errorf("%w: %w", ErrUpdateFailed, err)
+		}
+		l.Info("CA certificates updated successfully")
 	}
-	l.Info("CA certificates updated successfully")
+
 	return nil
 }

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -2,6 +2,7 @@
 package cert
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 
@@ -11,7 +12,7 @@ import (
 
 const (
 	// oktetocaCertPath is the path to the CA certificate
-	oktetocaCertPath = "/usr/local/share/ca-certificates/okteto_ca_cert.crt"
+	oktetocaCertPath = "/etc/ssl/certs/okteto_ca_cert.pem"
 
 	// updateCaCertificatesCmd is the command to update the CA certificates
 	updateCaCertificatesCmd = "update-ca-certificates"
@@ -45,6 +46,11 @@ func HandleCaCert(caCert string, runner command.CommandRunner, fs afero.Fs, l In
 
 	cmd := exec.Command(updateCaCertificatesCmd)
 	if err := runner.Run(cmd); err != nil {
+		var execErr *exec.Error
+		if errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound) {
+			l.Info("update-ca-certificates not found, skipping")
+			return nil
+		}
 		return fmt.Errorf("%w: %w", ErrUpdateFailed, err)
 	}
 	l.Info("CA certificates updated successfully")

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -2,7 +2,6 @@
 package cert
 
 import (
-	"errors"
 	"fmt"
 	"os/exec"
 
@@ -12,7 +11,7 @@ import (
 
 const (
 	// oktetocaCertPath is the path to the CA certificate
-	oktetocaCertPath = "/etc/ssl/certs/okteto_ca_cert.pem"
+	oktetocaCertPath = "/usr/local/share/ca-certificates/okteto_ca_cert.crt"
 
 	// updateCaCertificatesCmd is the command to update the CA certificates
 	updateCaCertificatesCmd = "update-ca-certificates"
@@ -46,11 +45,6 @@ func HandleCaCert(caCert string, runner command.CommandRunner, fs afero.Fs, l In
 
 	cmd := exec.Command(updateCaCertificatesCmd)
 	if err := runner.Run(cmd); err != nil {
-		var execErr *exec.Error
-		if errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound) {
-			l.Info("update-ca-certificates not found, skipping")
-			return nil
-		}
 		return fmt.Errorf("%w: %w", ErrUpdateFailed, err)
 	}
 	l.Info("CA certificates updated successfully")

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -70,6 +70,19 @@ func TestHandleCaCert(t *testing.T) {
 			expectError: ErrUpdateFailed,
 		},
 		{
+			name:   "update-ca-certificates not found",
+			caCert: "dummy-cert",
+			setupFs: func() afero.Fs {
+				return afero.NewMemMapFs()
+			},
+			setupRunner: func() *fakeCommandRunner {
+				return &fakeCommandRunner{
+					err: &exec.Error{Name: "update-ca-certificates", Err: exec.ErrNotFound},
+				}
+			},
+			expectError: nil,
+		},
+		{
 			name:   "successful case",
 			caCert: "dummy-cert",
 			setupFs: func() afero.Fs {

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -70,19 +70,6 @@ func TestHandleCaCert(t *testing.T) {
 			expectError: ErrUpdateFailed,
 		},
 		{
-			name:   "update-ca-certificates not found",
-			caCert: "dummy-cert",
-			setupFs: func() afero.Fs {
-				return afero.NewMemMapFs()
-			},
-			setupRunner: func() *fakeCommandRunner {
-				return &fakeCommandRunner{
-					err: &exec.Error{Name: "update-ca-certificates", Err: exec.ErrNotFound},
-				}
-			},
-			expectError: nil,
-		},
-		{
 			name:   "successful case",
 			caCert: "dummy-cert",
 			setupFs: func() afero.Fs {

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -26,11 +26,15 @@ type fakeInfoLogger struct{}
 func (fil *fakeInfoLogger) Info(_ string, _ ...interface{}) {}
 
 func TestHandleCaCert(t *testing.T) {
+	notFound := func(string) (string, error) { return "", errors.New("not found") }
+	found := func(string) (string, error) { return "/usr/bin/update-ca-certificates", nil }
+
 	tests := []struct {
 		name        string
 		caCert      string
 		setupFs     func() afero.Fs
 		setupRunner func() *fakeCommandRunner
+		lookPath    LookPathFunc
 		expectError error
 	}{
 		{
@@ -42,6 +46,7 @@ func TestHandleCaCert(t *testing.T) {
 			setupRunner: func() *fakeCommandRunner {
 				return &fakeCommandRunner{}
 			},
+			lookPath:    notFound,
 			expectError: nil,
 		},
 		{
@@ -54,6 +59,7 @@ func TestHandleCaCert(t *testing.T) {
 			setupRunner: func() *fakeCommandRunner {
 				return &fakeCommandRunner{}
 			},
+			lookPath:    notFound,
 			expectError: ErrWriteFailed,
 		},
 		{
@@ -67,6 +73,7 @@ func TestHandleCaCert(t *testing.T) {
 				runner.err = errors.New("update failed")
 				return runner
 			},
+			lookPath:    found,
 			expectError: ErrUpdateFailed,
 		},
 		{
@@ -76,9 +83,9 @@ func TestHandleCaCert(t *testing.T) {
 				return afero.NewMemMapFs()
 			},
 			setupRunner: func() *fakeCommandRunner {
-				runner := &fakeCommandRunner{}
-				return runner
+				return &fakeCommandRunner{}
 			},
+			lookPath:    notFound,
 			expectError: nil,
 		},
 	}
@@ -88,7 +95,7 @@ func TestHandleCaCert(t *testing.T) {
 			fs := tt.setupFs()
 			runner := tt.setupRunner()
 
-			err := HandleCaCert(tt.caCert, runner, fs, &fakeInfoLogger{})
+			err := HandleCaCert(tt.caCert, runner, tt.lookPath, fs, &fakeInfoLogger{})
 
 			assert.ErrorIs(t, err, tt.expectError)
 		})


### PR DESCRIPTION
Write CA cert to /etc/ssl/certs/ (read directly by Go runtime) and
skip update-ca-certificates gracefully when not found in PATH.


## Tests done

### Before
```bash
> git checkout main  && docker build --no-cache -t test . && docker run --rm -e OKTETO_TOKEN=$TOKEN -e OKTETO_URL=$URL -e OKTETO_CA_CERT="$CA" test "a" "aa" "aa" "false" "false" "var" "5m" "" ""


time=2026-03-18T14:08:45.643Z level=INFO msg="Starting execution..."
time=2026-03-18T14:08:45.649Z level=ERROR msg="Error handling CA certificate: %v" error="failed to write CA cert: open /usr/local/share/ca-certificates/okteto_ca_cert.crt: no such file or directory"
```

### After


```bash
> git checkout jlo/fix-ca  && docker build --no-cache -t test . && docker run --rm -e OKTETO_TOKEN=$TOKEN -e OKTETO_URL=$URL -e OKTETO_CA_CERT="$CA" test "a" "aa" "aa" "false" "false" "var" "5m" "" ""

time=2026-03-18T14:24:45.747Z level=INFO msg="Starting execution..."
time=2026-03-18T14:24:45.757Z level=INFO msg="CA certificate written successfully"
time=2026-03-18T14:24:45.765Z level=INFO msg="update-ca-certificates not found, skipping"
time=2026-03-18T14:24:45.785Z level=INFO msg="Executing command: okteto [test  --name=a --namespace=aa --file=aa --var=var --timeout=5m]"
 !  Initializing context with the value of OKTETO_URL and OKTETO_TOKEN environment variables
 !  No access to namespace 'aa' switching to personal namespace 'okteto-admin'
 ✓  Context 'okteto.test-javi.dev.okteto.net' created
 i  Using okteto-admin @ okteto.test-javi.dev.okteto.net as context
 x  The Okteto manifest specified does not exist
    Check the path to the Okteto manifest file
time=2026-03-18T14:24:49.605Z level=ERROR msg="Command execution failed " error="exit status 1"

```



